### PR TITLE
Allow cu.* as well as tty.* for Darwin

### DIFF
--- a/src/Stream/Serial/Device.php
+++ b/src/Stream/Serial/Device.php
@@ -52,7 +52,7 @@ namespace Carica\Io\Stream\Serial {
           $this->_baudRates[$baud]
         );
       } elseif (substr(PHP_OS, 0, 6) === "Darwin") {
-        $pattern = '(^/dev/tty\.[^\s]+$)';
+        $pattern = '(^/dev/(?:tty|cu)\.[^\s]+$)';
         $command = sprintf('stty -f %s speed %d', $device, $baud);
       } elseif (substr(PHP_OS, 0, 5) === "Linux") {
         $pattern = '(^/dev/tty\w+\d+$)';


### PR DESCRIPTION
This change allows `/dev/cu.usbmodem1421` as well as `/dev/tty.usbmodem1421` in situations where either could be valid.
